### PR TITLE
Remove orphaned captions

### DIFF
--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -581,22 +581,6 @@
 						<td>Ah, my parent! Well, what of that? I’m not ashamed of my parent. I can pay my respects to my parent. How d’you do, father? <i epub:type="z3998:stage-direction">Bows and puts out his hand.</i> My respects to you.</td>
 					</tr>
 					<tr>
-						<td epub:type="z3998:persona">Anísya</td>
-						<td>Come in!</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Nikíta</td>
-						<td>Ah, that’s it.</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Anísya</td>
-						<td>You look who’s in the hut!</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Nikíta</td>
-						<td>Ah, my parent! Well, what of that? I’m not ashamed of my parent.</td>
-					</tr>
-					<tr>
 						<td epub:type="z3998:persona">Akím</td>
 						<td><i epub:type="z3998:stage-direction">Does not answer.</i> Drink, I mean drink, what it does! It’s filthy!</td>
 					</tr>
@@ -667,18 +651,6 @@
 					<tr>
 						<td epub:type="z3998:persona">Anísya</td>
 						<td><i epub:type="z3998:stage-direction">Going out with the samovar.</i> Her box is full as it is, and still he’s bought more!</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Nikíta</td>
-						<td>Have you brought all the parcels?</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Akoulína</td>
-						<td>The parcels? I’ve brought mine, the rest’s in the sledge.</td>
-					</tr>
-					<tr>
-						<td epub:type="z3998:persona">Anísya</td>
-						<td>Her box is full as it is, and still he’s bought more!</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Nikíta</td>

--- a/src/epub/text/act-5.xhtml
+++ b/src/epub/text/act-5.xhtml
@@ -482,18 +482,6 @@
 							<td>Why fear such muck as they are? You look at ’em in the bathhouse! All made of one paste! One has a bigger belly, another a smaller; that’s all the difference there is! Fancy being afraid of ’em! Deuce take ’em!</td>
 						</tr>
 						<tr>
-							<td epub:type="z3998:persona">Nikíta</td>
-							<td>True enough! What was I about?</td>
-						</tr>
-						<tr>
-							<td epub:type="z3998:persona">Mítritch</td>
-							<td>What?</td>
-						</tr>
-						<tr>
-							<td epub:type="z3998:persona">Nikíta</td>
-							<td>You tell me not to fear men?</td>
-						</tr>
-						<tr>
 							<td epub:type="z3998:persona">Mítritch</td>
 							<td>Why fear such muck as they are? You look at ’em in the bathhouse!</td>
 						</tr>


### PR DESCRIPTION
There are a few sections in the scans where there's an image captioned with a few lines from the drama. The images aren't included in the ebook, but the captions for them are, which gives the impression that the characters are repeating themselves. Looks like the images were intentionally removed in [this commit](https://github.com/standardebooks/leo-tolstoy_the-power-of-darkness_louise-maude_aylmer-maude/commit/df0d894bfa80eaa96e80d7e14762dddeaca0f72c), so I think it makes sense to get rid of the caption text that accompanied them.

**Act 3**

<img width="772" height="557" alt="Screenshot 2025-09-21 at 10 12 18 AM" src="https://github.com/user-attachments/assets/90bc2490-7d7a-4183-8589-1330e1bcedfd" />

<img width="821" height="574" alt="Screenshot 2025-09-21 at 10 07 04 AM" src="https://github.com/user-attachments/assets/e7520a20-e621-42fc-9168-883bea0e4996" />

**Act 5**

<img width="774" height="559" alt="Screenshot 2025-09-21 at 10 14 56 AM" src="https://github.com/user-attachments/assets/9a7057de-698e-4c12-a4dc-a21ffffdc825" />
