### PR TITLE
Fix spelling mistake in Dramatis Personae

### DIFF
--- a/src/epub/text/dramatis-personae.xhtml
+++ b/src/epub/text/dramatis-personae.xhtml
@@ -10,7 +10,7 @@
 			<h2 epub:type="title">Dramatis Personae</h2>
 			<ul>
 				<li>
-					<p>Peter Ignátitch. A well-to-do peasant, fourty-two years old, married for the second time, and sickly</p>
+					<p>Peter Ignátitch. A well-to-do peasant, forty-two years old, married for the second time, and sickly</p>
 				</li>
 				<li>
 					<p>Anísya. His wife, thirty-two years old, fond of dress</p>


### PR DESCRIPTION
This spelling mistake was introduced when the original producer spelled out some numbers in an editorial commit.